### PR TITLE
Fixed regex for file ending tests

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -23,10 +23,10 @@ var paths = {
     scriptsDevServer: 'devServer/**/*.js'
 };
 
-var jsScriptsRegex =  /.js$/i;
-var cssStylesRegex = /.css$/i;
-var lessStylesRegex = /.less$/i;
-var fontsStylesRegex = /.(ttf|woff|eot|svg|woff2)$/i;
+var jsScriptsRegex =  /\.js$/i;
+var cssStylesRegex = /\.css$/i;
+var lessStylesRegex = /\.less$/i;
+var fontsStylesRegex = /\.(ttf|woff|eot|svg|woff2)$/i;
 
 // == PIPE SEGMENTS ========
 


### PR DESCRIPTION
Hey,
you forgot to escape the dots in the patterns, which lead in my setup to both a ".scss" as well as a ".css" file from bower_components being included (and crashing the css minimizer).
